### PR TITLE
FIX: ignore all .ipynb_checkpoints in subdirectories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 .DS_Store
-.ipynb_checkpoints/*
+.ipynb_checkpoints


### PR DESCRIPTION
Before this was just ignoring .ipynb_checkpoints in the main directory, but this fix should ignore the checkpoint directories in all sub-directories as well.